### PR TITLE
feat: added the permissions in the events CURD

### DIFF
--- a/django_ems/events/views.py
+++ b/django_ems/events/views.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 from django_ems.events.models import Events
 from django_ems.events.serializers import EventsSerializer
@@ -8,7 +8,7 @@ from django_ems.events.serializers import EventsSerializer
 class EventsViewSet(viewsets.ModelViewSet):
     queryset = Events.objects.all().order_by("id")
     serializer_class = EventsSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticatedOrReadOnly]
 
     def perform_create(self, serializer: EventsSerializer):
         serializer.save(owner=self.request.user)


### PR DESCRIPTION
## Overview
- Added permissions in the events CURD.
- The GET `/events` endpoint is accessible by anyone i.e., publicly available along with GET `/events/<event_id>` endpoint.
- All the other endpoints require the authentication i.e., `POST`, `PUT`, `PATCH` and `DELETE`.