### PR TITLE
feat: update and delete events can be perform by the owner

### DIFF
--- a/django_ems/events/views.py
+++ b/django_ems/events/views.py
@@ -1,14 +1,26 @@
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.permissions import (
+    SAFE_METHODS,
+    BasePermission,
+    IsAuthenticatedOrReadOnly,
+)
+from rest_framework.request import Request
 
 from django_ems.events.models import Events
 from django_ems.events.serializers import EventsSerializer
 
 
+class IsOwner(BasePermission):
+    def has_object_permission(
+        self, request: Request, view: "EventsViewSet", obj: Events
+    ) -> bool:
+        return True if request.method in SAFE_METHODS else request.user == obj.owner
+
+
 class EventsViewSet(viewsets.ModelViewSet):
     queryset = Events.objects.all().order_by("id")
     serializer_class = EventsSerializer
-    permission_classes = [IsAuthenticatedOrReadOnly]
+    permission_classes = [IsAuthenticatedOrReadOnly, IsOwner]
 
     def perform_create(self, serializer: EventsSerializer):
         serializer.save(owner=self.request.user)


### PR DESCRIPTION
## Overview
- Added `owner_id` condition in PUT `/events/<event_id>` endpoint i.e., only the owner of the event can update the event and delete it.
- Added `owner_id` condition in DELETE `/events/<event_id>` endpoint i.e., only the owner of the event can delete the event and delete it.