### PR TITLE
feat: added attend and drop event endpoints

### DIFF
--- a/django_ems/events/views.py
+++ b/django_ems/events/views.py
@@ -1,10 +1,12 @@
-from rest_framework import viewsets
+from rest_framework import decorators, status, viewsets
 from rest_framework.permissions import (
     SAFE_METHODS,
     BasePermission,
+    IsAuthenticated,
     IsAuthenticatedOrReadOnly,
 )
 from rest_framework.request import Request
+from rest_framework.response import Response
 
 from django_ems.events.models import Events
 from django_ems.events.serializers import EventsPagination, EventsSerializer
@@ -25,3 +27,30 @@ class EventsViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer: EventsSerializer):
         serializer.save(owner=self.request.user)
+
+    @decorators.action(
+        url_path="attendees",
+        methods=["POST", "DELETE"],
+        detail=True,
+        permission_classes=[IsAuthenticated],
+    )
+    def attendees(self, request: Request, pk: int | None = None) -> Response:
+        return {"POST": self._attend_events, "DELETE": self._drop_events}[
+            request.method
+        ](request, pk)
+
+    def _attend_events(self, request: Request, pk: int | None = None) -> Response:
+        event: Events = self.get_object()
+        event.attendees.add(request.user)
+        return Response(
+            data={"detail": "You have been added to the event."},
+            status=status.HTTP_201_CREATED,
+        )
+
+    def _drop_events(self, request: Request, pk: int | None = None) -> Response:
+        event: Events = self.get_object()
+        event.attendees.remove(request.user)
+        return Response(
+            data={"detail": "You have been removed from the event."},
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
## Overview:
- Add the attend event endpoint i.e., POST `/events/<event_id>/attendees`.
- Added the drop event endpoint i.e., DELETE `/events/<event_id>/attendees`.